### PR TITLE
Build fuseki and dataloader

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,82 @@
+# https://docs.github.com/en/actions/publishing-packages/publishing-docker-images#publishing-images-to-github-packages
+name: Create and publish a Docker image
+
+on:
+  push:
+    tags:
+      - '*'
+
+permissions:
+    contents: read
+    packages: write
+
+jobs:
+  build-and-push-fuseki:
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository_owner }}/lock-unlock-fuseki
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          context: fuseki-docker
+          build-args: |
+            JENA_VERSION=4.10.0
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  build-and-push-dataloader:
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository_owner }}/lock-unlock-dataloader
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          context: lock-unlock-dataloader
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/lock-unlock-dataloader/prep_tdb2.sh
+++ b/lock-unlock-dataloader/prep_tdb2.sh
@@ -13,14 +13,15 @@ fi
 
 # ----------------- Download  -----------------
 echo "Going to download $FILE_URL"
-curl -O $FILE_URL
+curl $FILE_URL -o $OUT_DIR/$FILENAME
 
 # -----------------  Unpack   -----------------
 if [[ "$FILENAME" == *.gz ]]; then
     echo "Unzipping dataset"
-    gzip -d $FILENAME
+    gzip -d $OUT_DIR/$FILENAME
     FILENAME=$(basename "$FILENAME" .gz)
 fi
 
 # ----------------- Load data -----------------
-/jena/bin/tdb2.tdbloader --loc $OUT_DIR $FILENAME
+/jena/bin/tdb2.tdbloader --loc $OUT_DIR $OUT_DIR/$FILENAME
+rm $OUT_DIR/$FILENAME


### PR DESCRIPTION
Added workflow for building these images as well:
- lock-unlock-fuseki
- lock-unlock-dataloader

Without building we cannot deploy in the cloud 😉 Has been tested in a [separate repo](https://github.com/kad-busses/lock-unlock-testdata), in this example, the Release was tied to 0.0.2 tag, images get that version as well.

![image](https://github.com/kadaster-labs/lock-unlock-testdata/assets/56066664/c9785799-55c7-4e26-934d-b532d4b64538)
